### PR TITLE
Add an option for the initial opening tab

### DIFF
--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -18,6 +18,7 @@
 
         defaults: {
             showfirst  : true,
+            opentab    : 0,
             collapse   : true,
             animate    : true,
             easing     : 'swing',
@@ -59,10 +60,14 @@
             });
 
             this.update();
-
-            if (this.options.showfirst) {
-                this.toggleItem(this.toggle.eq(0).data('wrapper'), false, false);
-            }
+            
+            if (this.options.opentab !== 0) {
+                this.toggleItem(this.toggle.eq(this.options.opentab-1).data('wrapper'), false, false);
+            } else {
+                if (this.options.showfirst) {
+                    this.toggleItem(this.toggle.eq(0).data('wrapper'), false, false);
+                }
+            }    
         },
 
         toggleItem: function(wrapper, animated, collapse) {


### PR DESCRIPTION
Adding the ability to specify which tab to display the open after the page loads.
Ex.  <div class="uk-accordion" data-uk-accordion="{opentab: 2}" >
